### PR TITLE
se paso insert_masivo a pdo.

### DIFF
--- a/php/lib/db/toba_db_postgres7.php
+++ b/php/lib/db/toba_db_postgres7.php
@@ -298,7 +298,7 @@ class toba_db_postgres7 extends toba_db
                    }
                 } catch (PDOException $e) {
                    $this->log($e->getMessage(), 'error');
-                   $ee = new toba_error_db($e, $this->cortar_sql($sql), $this->parser_errores, true);
+                   $ee = new toba_error_db($e, $sql);
                    throw $ee;
                 }
                 return $funciono;

--- a/php/lib/db/toba_db_postgres7.php
+++ b/php/lib/db/toba_db_postgres7.php
@@ -275,7 +275,7 @@ class toba_db_postgres7 extends toba_db
 	}
 
 	/**
-	* Insert de datos desde un arreglo hacia una tabla. Requiere la extension original pgsql.
+	* Insert de datos desde un arreglo hacia una tabla. Ahora usa pdo!
 	* @param string $tabla Nombre de la tabla en la que se insertarán los datos
 	* @param array $datos Los datos a insertar: cada elemento del arreglo será un registro en la tabla.
 	* @param string $delimitador Separador de datos de cada fila.
@@ -283,17 +283,25 @@ class toba_db_postgres7 extends toba_db
 	* @return boolean Retorn TRUE en caso de éxito o FALSE en caso de error.
 	*/
 	function insert_masivo($tabla,$datos,$delimitador="\t",$valor_nulo="\\N") {
-		$dbconn = $this->get_pg_connect_nativo();
-		$salida = pg_copy_from($dbconn,$tabla,$datos,$delimitador,$valor_nulo);
-		if (!$salida) {
-			$mensaje = pg_last_error($dbconn);
-			pg_close($dbconn);
-			//toba::logger()->error($mensaje);
-			$this->log($mensaje, 'error');
-			throw new toba_error($mensaje);
-		}
-		pg_close($dbconn);
-		return $salida;
+                $funciono = true;
+                // se genera el sql equivalente para los logs
+                $sql = "-- COPY $tabla FROM stdin de ".count($elementos)." filas.";
+                $sql = $this->pegar_estampilla_log($sql);
+                try {
+                   if ($this->registrar_ejecucion) {
+                     $this->registro_ejecucion[] = $sql;
+                   }
+                   if (! $this->desactivar_ejecucion) {
+                      if ($this->debug) $this->log_debug_inicio($sql);
+                      $funciono = $this->conexion->pgsqlCopyFromArray($tabla,$datos,$delimitador,$valor_nulo);
+                      if ($this->debug) $this->log_debug_fin();
+                   }
+                } catch (PDOException $e) {
+                   $this->log($e->getMessage(), 'error');
+                   $ee = new toba_error_db($e, $this->cortar_sql($sql), $this->parser_errores, true);
+                   throw $ee;
+                }
+                return $funciono;
 	}
 
 	/**


### PR DESCRIPTION
insert_masivo usa pdo.
- ya no abre una conexión a parte
- esto ultimo lo hace transaccionable
- logguea un comentario para que la víctima pueda ver porque y donde detonó
