### PR TITLE
Se implementa el acceso a la metadata del SP

### DIFF
--- a/php/nucleo/lib/autenticacion/toba_autenticacion_saml_onelogin.php
+++ b/php/nucleo/lib/autenticacion/toba_autenticacion_saml_onelogin.php
@@ -86,6 +86,19 @@ class toba_autenticacion_saml_onelogin extends toba_autenticacion implements tob
 			}
 			return $id_usuario;
 			
+		} elseif (! is_null(toba::memoria()->get_parametro('metadata'))) {					//Se devuelve los metadatos del SP
+
+			$settings = $auth->getSettings();
+			$metadata = $settings->getSPMetadata();
+			$errors = $settings->validateMetadata($metadata);
+			if (empty($errors)) {
+				header('Content-Type: text/xml');
+				echo $metadata;
+			} else {
+				echo "Invalid SP metadata";
+			}
+			die;
+
 		} else {
 			$this->procesar_logout($auth);
 			


### PR DESCRIPTION
La idea es poder acceder a la información acerca del SP, necesaria para su validación y/o configuración en un IDP. La lib php-saml nos da un [endpoint](https://github.com/onelogin/php-saml#endpoints) en el cual consultarlo.

Esto está implementado como `http://app.local?metadata`, de forma similar a como se maneja el **acs** o **sls**:

