### PR TITLE
Araí: evitar exportar cuentas de usuarios bloqueadas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## CHANGELOG
 
 [CURRENT](https://github.com/SIU-Toba/framework/compare/master...develop)
+- Nueva opción `--excluir-bloqueads` para el comando `exportar_usuarios_arai`, evita exportar las cuentas bloqueadas
 
 [3.2.1](https://github.com/SIU-Toba/framework/releases/tag/v3.2.1) (2019-02-28)
 - Undo de braindead merge by gitflow

--- a/php/modelo/aplicacion/toba_aplicacion_comando_base.php
+++ b/php/modelo/aplicacion/toba_aplicacion_comando_base.php
@@ -120,6 +120,7 @@ class toba_aplicacion_comando_base implements toba_aplicacion_comando
 	 *			'-m' => 'toba',
 	 *			'-e' => 'toba@siu.edu.ar',
 	 *			'--mascara' => "<apellido>, <nombres>" O una combinacion de patron similar
+	 *			'--excluir-bloqueados'  para indicar que no se quieren las cuentas bloqueadas
 	 * 		)
 	 * @throws Exception
 	 */
@@ -144,9 +145,10 @@ class toba_aplicacion_comando_base implements toba_aplicacion_comando
 			throw new toba_error("No se pudo crear la carpeta $pathMigration. ¿Problemas de permisos?");
 		}
 		$tokens = (isset($parametros['--mascara'])) ? $this->recuperar_tokens_indicativos($parametros['--mascara']) : array();
+		$excluir_bloqueados = isset($parametros['--excluir-bloqueados']);
 		
 		// obtengo los usuarios para generar el JSON
-		$datosUsuarios = $this->modelo->getDatosUsuarios($tokens);
+		$datosUsuarios = $this->modelo->getDatosUsuarios($tokens, $excluir_bloqueados);
 		$totalUsuarios = count($datosUsuarios);
 
 		// Inicializo la barra de progreso

--- a/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
+++ b/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
@@ -623,9 +623,13 @@ class toba_aplicacion_modelo_base implements toba_aplicacion_modelo
 	 * 		)
 	 *
      */
-	public function getDatosUsuarios($tokens = array())
+	public function getDatosUsuarios($tokens = array(), $sin_bloqueados = false)
 	{
 		$db_arai = $this->get_instancia()->get_db();
+		$where = '1=1';
+		if ($sin_bloqueados) {
+			$where .= ' AND u.bloqueado = 0';
+		}
 		$sql = "SELECT  DISTINCT
 						u.usuario,
 						u.clave,
@@ -639,7 +643,8 @@ class toba_aplicacion_modelo_base implements toba_aplicacion_modelo
 						END autentificacion_arai,
 						u.bloqueado
 				FROM apex_usuario u
-				JOIN apex_usuario_proyecto up ON (u.usuario = up.usuario AND up.proyecto = :toba_proyecto) ";
+				JOIN apex_usuario_proyecto up ON (u.usuario = up.usuario AND up.proyecto = :toba_proyecto) 
+				WHERE $where";
 		$sentencia = $db_arai->sentencia_preparar($sql);
 		$datosUsuariosToba = $db_arai->sentencia_consultar($sentencia, array('toba_proyecto' => $this->get_proyecto()->get_id()));
 


### PR DESCRIPTION
En el comando para exportar cuentas de usuarios con la intención de
importarlas a Araí, se puede especificar ignorar las cuentas que estén
marcadas como bloqueadas. Con ello el JSON solo tendrá datos de cuentas
activas.