### PR TITLE
Configura versión de api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## CHANGELOG
 
 [CURRENT](https://github.com/SIU-Toba/framework/compare/master...develop)
+- Fix en toba_rest cuando se setea la versión de la api a partir de la del proyecto
 
 [3.2.2](https://github.com/SIU-Toba/framework/releases/tag/v3.2.2) (2019-03-13)
 - Agrega metodo a toba_usuario_basico para obtener el identificador en arai-usuario para la cuenta actualmente logueada

--- a/php/nucleo/lib/toba_rest.php
+++ b/php/nucleo/lib/toba_rest.php
@@ -69,8 +69,8 @@ class toba_rest
 			'encoding' => 'latin1'
 		);
 		$datos_ini_proyecto = $this->get_ini_proyecto();
-		if (!empty($datos_ini_proyecto) && isset($datos_ini_proyecto['version'])) {
-			$settings['api_version'] = $datos_ini_proyecto['version'];
+		if (!empty($datos_ini_proyecto) && isset($datos_ini_proyecto['proyecto']['version'])) {
+			$settings['api_version'] = $datos_ini_proyecto['proyecto']['version'];
 		}
 		$settings = array_merge($settings, $ini->get('settings', null, array(), false));
 
@@ -213,7 +213,7 @@ class toba_rest
 	protected function get_ini_proyecto()
 	{
 		$resultado = array();
-		if (toba::config()->existe_valor('proyecto', null, 'id')) {
+		if (toba::config()->existe_valor('proyecto', 'proyecto', 'id')) {
 			$resultado = toba::config()->get_seccion('proyecto');
 		}
 		return $resultado;


### PR DESCRIPTION
Por defecto, se debe configurar la versión de la api REST a partir del proyecto.ini. No estaba leyendo apropiadamente la estructura al acceder a los datos.