### PR TITLE
Especificar email del administrador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## CHANGELOG
 
 [CURRENT](https://github.com/SIU-Toba/framework/compare/master...develop)
+- Nueva opción `--usuario-email-admin` que permite especificar el email para la cuenta administrativa al momento de instalar el framework
 
 [3.2.2](https://github.com/SIU-Toba/framework/releases/tag/v3.2.2) (2019-03-13)
 - Agrega metodo a toba_usuario_basico para obtener el identificador en arai-usuario para la cuenta actualmente logueada

--- a/php/consola/comandos/comando_instalacion_silenciosa.php
+++ b/php/consola/comandos/comando_instalacion_silenciosa.php
@@ -84,8 +84,11 @@ class comando_instalacion_silenciosa extends comando_toba
 		$pwd = $this->definir_clave_usuario_admin($param);
 
 		$usr = $this->definir_usuario_admin($param);
+
+		$email = $this->definir_email_admin($param);
+
 		//--- Vincula un usuario a todos los proyectos y se instala el proyecto				
-		$instancia->agregar_usuario($usr, 'Usuario Administrador', $pwd);				
+		$instancia->agregar_usuario($usr, 'Usuario Administrador', $pwd, $email);
 		$instancia->exportar_local();
 		
 		//--- Crea los nuevos alias
@@ -447,6 +450,18 @@ class comando_instalacion_silenciosa extends comando_toba
 			return 'toba';
 		}
 		return $result['resultado'];
-	}	
+	}
+
+	protected function definir_email_admin($param)
+	{
+		$nombre_parametro = array('--usuario-email-admin');
+		$result = $this->recuperar_dato_y_validez($param, $nombre_parametro);
+
+		if ($result['invalido']) {
+			toba::logger()->error("No se se selecciono ningun email para usuario administrador, ya que uno válido no fue provisto");
+			return null;
+		}
+		return $result['resultado'];
+	}
 }
 ?>


### PR DESCRIPTION
Al momento de realizar la instalción del framework, en la cuenta de administrador que se crea, se hace posible pasar una opción vía CLI que permita especificar su dirección de correo electrónico.

Útil en casos como el despliegue automatizado de la plataforma SIU-Araí y la posterior gestión de la cuenta administradora. #43 