### PR TITLE
Estilos imagen icono origen-proyecto

### DIFF
--- a/proyectos/toba_editor/www/css/toba.css
+++ b/proyectos/toba_editor/www/css/toba.css
@@ -87,6 +87,8 @@
 }
 #editor_imagen_listado img {
 	vertical-align: middle;
+	max-width: 25px;
+	min-width: 20px;
 }
 #editor_imagen_listado table {
 	width: 100%;


### PR DESCRIPTION
Solucion al desborde que se da al tener que seleccionar un icono con origen/proyecto para
los botones.

![2019-09-12_09-33](https://user-images.githubusercontent.com/12787110/64786893-e56b8780-d545-11e9-8915-d3e1295fad4c.png)
