### PR TITLE
Setear tipo descarga en header http

### DIFF
--- a/php/nucleo/lib/salidas/toba_vista_jasperreports.php
+++ b/php/nucleo/lib/salidas/toba_vista_jasperreports.php
@@ -14,6 +14,8 @@ class toba_vista_jasperreports
 	protected $tipo_descarga = 'attachment';
 	protected $jasper;
 	protected $temp_salida;
+	protected $tipo_salida ='attachment';
+	
 
 	// Parametros para el reporte
 	protected $parametros;
@@ -414,7 +416,7 @@ class toba_vista_jasperreports
 	 */
 	protected function cabecera_http( $longitud )
 	{
-		toba_http::headers_download($this->tipo_descarga, $this->nombre_archivo, $longitud);
+		toba_http::headers_download($this->tipo_descarga, $this->nombre_archivo, $longitud, $this->tipo_salida);
 	}
 	
 

--- a/php/nucleo/lib/toba_http.php
+++ b/php/nucleo/lib/toba_http.php
@@ -55,12 +55,12 @@ class toba_http
 		}
 	}
 	
-	static function headers_download($tipo, $archivo, $longitud) 
+	static function headers_download($tipo, $archivo, $longitud, $disposition='attachment') 
 	{ 
 		header("Cache-Control: private"); 
 		header("Content-type: $tipo"); 
 		header("Content-Length: $longitud"); 
-		header("Content-Disposition: attachment; filename=$archivo"); 
+		header("Content-Disposition: $disposition; filename=$archivo"); 
 		header("Pragma: no-cache"); 
 		header("Expires: 0"); 
 


### PR DESCRIPTION
@enfoqueNativo en la version 3.1.x, necesitamos poder abrir directamente los pdf generados en jasper en el browser.