### PR TITLE
 Salvaguarda problema al vincular con arai-usuarios sin usar registry

### DIFF
--- a/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
+++ b/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
@@ -734,7 +734,10 @@ class toba_aplicacion_modelo_base implements toba_aplicacion_modelo
 	{
 		$appUniqueId = null;
 		if ($this->instalacion->vincula_arai_usuarios()) {
-			$appUniqueId = \SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId();
+			$appUniqueId = toba::instalacion()->vincula_arai_proyecto();
+			if (null === $appUniqueId) {
+				$appUniqueId = \SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId();
+			}
 		}
 		if (isset($appUniqueId)) {
 			$account->setAppUniqueId($appUniqueId);

--- a/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
+++ b/php/modelo/aplicacion/toba_aplicacion_modelo_base.php
@@ -734,7 +734,7 @@ class toba_aplicacion_modelo_base implements toba_aplicacion_modelo
 	{
 		$appUniqueId = null;
 		if ($this->instalacion->vincula_arai_usuarios()) {
-			$appUniqueId = toba::instalacion()->vincula_arai_proyecto();
+			$appUniqueId = $this->instalacion->vincula_arai_proyecto();
 			if (null === $appUniqueId) {
 				$appUniqueId = \SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId();
 			}

--- a/php/modelo/toba_modelo_instalacion.php
+++ b/php/modelo/toba_modelo_instalacion.php
@@ -1022,5 +1022,10 @@ class toba_modelo_instalacion extends toba_modelo_elemento
 		}
 		return array($min, $max);
 	}
+	
+	function vincula_arai_proyecto()
+	{
+		return toba::config()->get_parametro('instalacion', null, 'vincula_arai_appID');
+	}
 }
 ?>

--- a/php/nucleo/lib/toba_instalacion.php
+++ b/php/nucleo/lib/toba_instalacion.php
@@ -269,13 +269,21 @@ class toba_instalacion
 		return $conf;
 	}
 
-        /**
-         * Devuelve si la instalacion usa 2do Factor de Autenticacion
-         * @return boolean
-         */
-        function usa_2FA()
-        {
-            return (isset($this->memoria['usa_2do_factor']) && $this->memoria['usa_2do_factor'] == 1);
-        }
+	/**
+	 * Devuelve si la instalacion usa 2do Factor de Autenticacion
+	 * @return boolean
+	 */
+	function usa_2FA()
+	{
+		return (isset($this->memoria['usa_2do_factor']) && $this->memoria['usa_2do_factor'] == 1);
+	}
+	
+	function vincula_arai_proyecto()
+	{
+		if (isset($this->memoria['vincula_arai_appID'])) {
+			return $this->memoria['vincula_arai_appID'];
+		} 
+		return null;
+	}
 }
 ?>

--- a/proyectos/toba_usuarios/php/usuarios/gestion_arai_usuarios.php
+++ b/proyectos/toba_usuarios/php/usuarios/gestion_arai_usuarios.php
@@ -13,7 +13,7 @@ class gestion_arai_usuarios
 				$datos['cuenta'] = $datos['usuario'];	
 			}
 			if (! isset($datos['usuario_arai']) && isset($datos['cuenta']) && self::verifica_version_arai_cli()) {
-				$datos['usuario_arai'] = rest_arai_usuarios::instancia()->get_identificador_x_aplicacion_cuenta(SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId(), $datos['cuenta']);
+				$datos['usuario_arai'] = rest_arai_usuarios::instancia()->get_identificador_x_aplicacion_cuenta(self::getIdAplicacion(), $datos['cuenta']);
 			}
 		}
 		return $datos;
@@ -53,7 +53,7 @@ class gestion_arai_usuarios
 	{	
 		$resultado = true;
 		if (toba::instalacion()->vincula_arai_usuarios() && self::verifica_version_arai_cli()) {
-			$appUniqueId = SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId();
+			$appUniqueId = self::getIdAplicacion();
 			$identificador_arai_usuarios = rest_arai_usuarios::instancia()->get_identificador_x_aplicacion_cuenta($appUniqueId, $cuenta);
 			if (!isset($identificador_arai_usuarios)) {
 				$datos_cuenta = array(
@@ -73,7 +73,7 @@ class gestion_arai_usuarios
 	{	
 		$resultado = true;
 		if (toba::instalacion()->vincula_arai_usuarios() && self::verifica_version_arai_cli()) {
-			$resultado = rest_arai_usuarios::instancia()->eliminar_cuenta(SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId(), $cuenta);
+			$resultado = rest_arai_usuarios::instancia()->eliminar_cuenta(self::getIdAplicacion(), $cuenta);
 		}
 		return $resultado;
 	}
@@ -97,7 +97,7 @@ class gestion_arai_usuarios
 	{
 		$datos = array();
 		if (toba::instalacion()->vincula_arai_usuarios() && self::verifica_version_arai_cli()) {
-			$datos = rest_arai_usuarios::instancia()->get_usuarios($filtro, SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId());
+			$datos = rest_arai_usuarios::instancia()->get_usuarios($filtro, self::getIdAplicacion());
 		}
 		return $datos;
 	}
@@ -134,5 +134,14 @@ class gestion_arai_usuarios
 
 		return true;
  	}
+	
+	static private function getIdAplicacion()
+	{
+		$appID = toba::instalacion()->vincula_arai_proyecto();
+		if (null === $appID) {
+			$appID = SIUToba\Framework\Arai\RegistryHooksProyectoToba::getAppUniqueId();
+		}
+		return $appID;
+	}
 }
 ?>


### PR DESCRIPTION
- Agrega parametro a instalacion.ini 
- Agrega lectura del parametro en toba_usuarios previo a invocar llamadas a la api arai_usuarios
- Agrega lectura del parametro en el modelo, previo a la exportacion de usuarios para arai

Fix #88 