### PR TITLE
Perfiles no compilados en ambientes dockerizados

### DIFF
--- a/php/modelo/template_proyecto/www/aplicacion.php
+++ b/php/modelo/template_proyecto/www/aplicacion.php
@@ -6,6 +6,9 @@ define('apex_pa_proyecto', '__proyecto__');
 # Ejecuta con metadatos compilados de manera forzada (setear en instancia.ini, no descomentar aqui)
 #define('apex_pa_metadatos_compilados', 1);
 
+# Deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados
+#define('apex_pa_permisos_compilados', 0);
+
 # Deshabilita el autologin
 #define("apex_pa_validacion_debug", 0);
 

--- a/php/modelo/template_proyecto/www/aplicacion.php
+++ b/php/modelo/template_proyecto/www/aplicacion.php
@@ -6,8 +6,8 @@ define('apex_pa_proyecto', '__proyecto__');
 # Ejecuta con metadatos compilados de manera forzada (setear en instancia.ini, no descomentar aqui)
 #define('apex_pa_metadatos_compilados', 1);
 
-# Deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados
-#define('apex_pa_permisos_compilados', 0);
+# Habilita/deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados (default: activo)
+define('apex_pa_permisos_compilados', 1);
 
 # Deshabilita el autologin
 #define("apex_pa_validacion_debug", 0);

--- a/php/modelo/template_proyecto/www/aplicacion.produccion.php
+++ b/php/modelo/template_proyecto/www/aplicacion.produccion.php
@@ -6,6 +6,9 @@ define('apex_pa_proyecto', '__proyecto__');
 # Ejecuta con metadatos compilados
 define('apex_pa_metadatos_compilados', 1);
 
+# Recupera directamente los permisos desde bd, util entornos dockerizados
+#define('apex_pa_permisos_compilados', 0);
+
 # Deshabilita el autologin
 define('apex_pa_validacion_debug', 0);
 

--- a/php/modelo/template_proyecto/www/aplicacion.produccion.php
+++ b/php/modelo/template_proyecto/www/aplicacion.produccion.php
@@ -6,7 +6,7 @@ define('apex_pa_proyecto', '__proyecto__');
 # Ejecuta con metadatos compilados
 define('apex_pa_metadatos_compilados', 1);
 
-# Recupera directamente los permisos desde bd, util entornos dockerizados
+# Deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados
 #define('apex_pa_permisos_compilados', 0);
 
 # Deshabilita el autologin

--- a/php/modelo/template_proyecto/www/aplicacion.produccion.php
+++ b/php/modelo/template_proyecto/www/aplicacion.produccion.php
@@ -6,8 +6,8 @@ define('apex_pa_proyecto', '__proyecto__');
 # Ejecuta con metadatos compilados
 define('apex_pa_metadatos_compilados', 1);
 
-# Deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados
-#define('apex_pa_permisos_compilados', 0);
+# Habilita/deshabilita uso de permisos desde metadatos_compilados, util para entornos dockerizados (default: activo)
+define('apex_pa_permisos_compilados', 1);
 
 # Deshabilita el autologin
 define('apex_pa_validacion_debug', 0);

--- a/php/nucleo/lib/toba_instancia.php
+++ b/php/nucleo/lib/toba_instancia.php
@@ -153,6 +153,14 @@ class toba_instancia
 		return null;
 	}
 
+	function get_directiva_compilacion_perfiles($proyecto)
+	{
+		if (isset($this->memoria[$proyecto]['perfiles_compilados'])) {
+			return $this->memoria[$proyecto]['perfiles_compilados'];
+		}
+		return null;
+	}
+	
 	function get_largo_minimo_password()
 	{
 		if (isset($this->memoria['pwd_largo_minimo'])) {

--- a/php/nucleo/lib/toba_proyecto.php
+++ b/php/nucleo/lib/toba_proyecto.php
@@ -397,7 +397,7 @@ class toba_proyecto
 	{
 		if (!isset($proyecto)) { $proyecto = $this->id;}
 		if (!isset($grupos_acceso)) { $grupos_acceso = toba::manejador_sesiones()->get_perfiles_funcionales_activos();}
-		if ( toba::nucleo()->utilizar_metadatos_compilados( $proyecto ) ) {
+		if (toba::nucleo()->utilizar_metadatos_compilados($proyecto) && toba::nucleo()->usar_perfiles_compilados($proyecto)) {
 			$rs = $this->recuperar_datos_compilados_grupo(	'toba_mc_gene__grupo_',
 													$grupos_acceso,
 													'get_items_menu',
@@ -430,7 +430,7 @@ class toba_proyecto
 		//Recupero los items y los formateo en un indice consultable
 		if(!isset($this->indice_items_accesibles)) {
 			$this->indice_items_accesibles = array();
-			if ( toba::nucleo()->utilizar_metadatos_compilados( $this->id, 'compilados' ) ) {
+			if (toba::nucleo()->utilizar_metadatos_compilados($this->id, 'compilados' ) && toba::nucleo()->usar_perfiles_compilados($this->id)) {
 				///-- Metadatos compilados
 				if (! empty($grupos_acceso)) {
 					//-- Busca los items accesibles por grupo
@@ -462,7 +462,7 @@ class toba_proyecto
 	function get_items_zona($zona, $grupos_acceso=null)
 	{
 		if (!isset($grupos_acceso)) { $grupos_acceso = toba::manejador_sesiones()->get_perfiles_funcionales_activos();}
-		if ( toba::nucleo()->utilizar_metadatos_compilados( $this->id ) ) {
+		if (toba::nucleo()->utilizar_metadatos_compilados($this->id) && toba::nucleo()->usar_perfiles_compilados($this->id)) {
 			$rs = $this->recuperar_datos_compilados_grupo(	'toba_mc_gene__grupo_',
 															$grupos_acceso,
 															'get_items_zona__'.$zona,
@@ -492,7 +492,7 @@ class toba_proyecto
 
 	function get_perfiles_funcionales_asociados($perfil)
 	{
-		if ( toba::nucleo()->utilizar_metadatos_compilados( $this->id ) ) {
+		if (toba::nucleo()->utilizar_metadatos_compilados($this->id) && toba::nucleo()->usar_perfiles_compilados($this->id)) {
 			$rs = $this->recuperar_datos_compilados_grupo(	'toba_mc_gene__grupo_',  array($perfil),	'get_membresia', true);
 			$perfiles = $rs;
 			foreach ($rs as $perfil_miembro) {
@@ -512,7 +512,7 @@ class toba_proyecto
 	function get_lista_permisos($grupos_acceso=null)
 	{
 		$grupos_acceso = isset($grupos_acceso) ? $grupos_acceso : toba::manejador_sesiones()->get_perfiles_funcionales_activos();
-		if ( toba::nucleo()->utilizar_metadatos_compilados( $this->id ) ) {
+		if (toba::nucleo()->utilizar_metadatos_compilados($this->id) && toba::nucleo()->usar_perfiles_compilados($this->id)) {
 			$rs = $this->recuperar_datos_compilados_grupo('toba_mc_gene__grupo_', $grupos_acceso, 'get_lista_permisos');
 		} else {
 			$rs = toba_proyecto_db::get_lista_permisos($this->id, $grupos_acceso);

--- a/php/nucleo/toba_nucleo.php
+++ b/php/nucleo/toba_nucleo.php
@@ -17,6 +17,9 @@ if (! defined('apex_pa_pwd_largo_minimo')) {
 	define('apex_pa_pwd_largo_minimo', '8');
 }
 
+if (! defined('apex_pa_permisos_compilados')) {
+	define('apex_pa_permisos_compilados', '1');	
+}
 /**
  * Clase que brinda las puertas de acceso al núcleo de toba
  * @package Centrales
@@ -488,7 +491,9 @@ class toba_nucleo
 			require_once( self::get_directorio_compilacion() . '/gene/toba_mc_gene__basicos.php' );
 			$grupos_acceso = toba::manejador_sesiones()->get_perfiles_funcionales_activos();
 			foreach( $grupos_acceso as $grupo ) {
-				require_once( self::get_directorio_compilacion() . '/gene/toba_mc_gene__grupo_'.$grupo.'.php' );
+				if ($this->usar_perfiles_compilados($item[0])) {
+					require_once( self::get_directorio_compilacion() . '/gene/toba_mc_gene__grupo_'.$grupo.'.php' );
+				}
 			}
 		}
 	}
@@ -510,6 +515,18 @@ class toba_nucleo
 		}
 	}
 
+	function usar_perfiles_compilados($proyecto=null)
+	{
+		$proyecto = isset($proyecto) ? $proyecto : toba_proyecto::get_id();
+		$flag = toba::instancia()->get_directiva_compilacion_perfiles($proyecto);
+		if(!isset($flag) && $proyecto == toba_proyecto::get_id()) {
+			//Mecanismo obsoleto
+			return (defined('apex_pa_perfiles_compilados') && apex_pa_perfiles_compilados);
+		}else{
+			return $flag;
+		}		
+	}	
+	
 	static function get_directorio_compilacion()
 	{
 		if(!self::$dir_compilacion) self::$dir_compilacion = toba_proyecto::get_path() . '/metadatos_compilados';

--- a/php/nucleo/toba_nucleo.php
+++ b/php/nucleo/toba_nucleo.php
@@ -521,7 +521,7 @@ class toba_nucleo
 		$flag = toba::instancia()->get_directiva_compilacion_perfiles($proyecto);
 		if(!isset($flag) && $proyecto == toba_proyecto::get_id()) {
 			//Mecanismo obsoleto
-			return (defined('apex_pa_perfiles_compilados') && apex_pa_perfiles_compilados);
+			return (defined('apex_pa_perfiles_compilados') && apex_pa_perfiles_compilados == 1);
 		}else{
 			return $flag;
 		}		

--- a/proyectos/toba_usuarios/php/lib/admin_instancia.php
+++ b/proyectos/toba_usuarios/php/lib/admin_instancia.php
@@ -77,7 +77,9 @@ class admin_instancia
 				$instancia->set_proyecto_usar_perfiles_propios($id_proyecto, true);
 			}
 			//-- Re-Compilamos los metadatos de perfiles 
-			$instancia->get_proyecto($id_proyecto)->compilar_metadatos_generales_grupos_acceso(true);
+			if (toba::nucleo()->usar_perfiles_compilados($id_proyecto)) {
+				$instancia->get_proyecto($id_proyecto)->compilar_metadatos_generales_grupos_acceso(true);
+			}
 		}		
 	}
 	


### PR DESCRIPTION
 Agrega metodo y constante para indicar que los perfiles funcionales se usen directamente desde la bd, inclusive usando metadatos compilados  Fix #104