### PR TITLE
Contemplar el uso de la variable de entorno JAVA_HOSTS para poder usar Jasper desde Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ web:
 #    TOBA_PROYECTO_ALIAS               : /miproyecto
 #    TOBA_PROYECTO_INSTALAR            : "true"
 #    TOBA_PROYECTO_INSTALAR_PARAMETROS : --base-nombre miproyecto
+## Descomentar para que el contenedor pueda usar el service jasper
+#    JAVA_HOSTS                        : jasper:7080
   links:
    - pg
 ## Activar este link si se desea utilizar el servidor de Jasper
@@ -36,6 +38,8 @@ web:
 # Descomentar este bloque si se desea utilizar el servidor Jasper (Por ahora esta sin testear)
 #jasper:
 ##  build: jasper/
+#  ports:
+#   - "7080:8081"
 #  image: siutoba/docker-guarani-jasper
 #  links:
 #   - pg

--- a/php/nucleo/lib/salidas/toba_vista_jasperreports.php
+++ b/php/nucleo/lib/salidas/toba_vista_jasperreports.php
@@ -56,7 +56,8 @@ class toba_vista_jasperreports
 	
 	protected function cargar_jasper()
 	{
-		if (!defined("JAVA_HOSTS")) define ("JAVA_HOSTS", "127.0.0.1:8081");
+		$java_hosts = is_null($_ENV["JAVA_HOSTS"]) ? "127.0.0.1:8081" : $_ENV["JAVA_HOSTS"];
+		define("JAVA_HOSTS", $java_hosts);
 		$path = $this->definir_path_vendor();
 				
 		//Incluimos la libreria JavaBridge


### PR DESCRIPTION
TL;DR: Tomando en cuenta la posibilidad de que exista la variable de entorno `JAVA_HOSTS`, un condicional en la carga del jasper puede hacer que se pueda utilizar el mismo desde un contenedor (Se deja un ejemplo del seteo de la variable en `docker-compose.yml`). Cuando la variable no esta seteada, conserva el comportamiento anterior.

Nota larga: Estamos tratando de dockerizar Toba, y tuvimos alguno inconvenientes en esta parte de usar jasper como servicio fuera de localhost. Primero se intento extender `toba_vista_jasperreports`, pero el mismo no se puede inyectar como dependencia al servicio de impresión.

La propuesta de este PR no es la mas elegante, pero creo que no rompe otra cosa. El bloque de jasper en `docker-compose.yml` no funciona asi como está, pero nosotros con algunas variaciones y creando nuestra propia imagen basada en [las archivadas de guarani](https://github.com/SIU-Toba/docker-guarani/blob/master/jasper/Dockerfile) lo pudimos hacer andar.

Si interesa, puedo proponer un yml acorde, lo que agregaría, al menos, un Dockerfile extra (el de Jasper en si).